### PR TITLE
fix weekly report label bug and defaultly disable auto label for bot

### DIFF
--- a/src/components/issueAutoLabel/index.ts
+++ b/src/components/issueAutoLabel/index.ts
@@ -23,6 +23,7 @@ export default class IssueAutoLabelComponent extends BaseComponent {
         // check config for not label
         if (!config.enable) return;
         if (config.notProcess(issue.title, issue.body, issue.user.login)) return;
+        if (context.isBot) return;
 
         let labelConfig = await this.app.configService.getConfigByContext(context, LabelSetupComponentConfig);
         let title = issue.title.toLowerCase();
@@ -41,7 +42,7 @@ export default class IssueAutoLabelComponent extends BaseComponent {
         let github = await this.app.installationsService.getGithubClientByContext(context);
         let param = context.issue({ labels: attachLabels });
         await github.issues.addLabels(param).catch(this.logger.error);
-        this.logger.debug(`Auto label for issue #${issue.number} done,` +
+        this.logger.info(`Auto label for issue #${issue.number} done,` +
             ` lalels=${JSON.stringify(attachLabels)}`);
     }
 }

--- a/src/components/weeklyReport/index.ts
+++ b/src/components/weeklyReport/index.ts
@@ -82,7 +82,8 @@ export default class WeeklyReportComponent extends BaseComponent {
             owner,
             repo,
             title,
-            body: weeklyReportStr
+            body: weeklyReportStr,
+            labels: ["weekly-report"]
         }).then(r => {
             this.logger.info(`Generate weekly report for ${owner}/${repo} done, issue number=${r.data.number}`);
         }).catch(e => {


### PR DESCRIPTION
The weekly report label is not gonna be labeled by auto label, add label while open the issue.

And disable auto label for bot by default.