### PR TITLE
fix install new repo with installation and load config delay

### DIFF
--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -145,10 +145,14 @@ export default class ConfigService extends BaseComponent {
     }
 
     public resetConfigByName(owner: string, repo: string) {
-        let key = this.genKey(owner, repo);
-        this.logger.info(`Config reset for ${key}`);
-        this.configs.delete(key);
-        this.app.eventService.trigger(ConfigChangedEvent, { owner, repo });
+        // TODO: no idea why can't get new config file right after the event
+        // give 5 seconds delay
+        setTimeout(() => {
+            let key = this.genKey(owner, repo);
+            this.logger.info(`Config reset for ${key}`);
+            this.configs.delete(key);
+            this.app.eventService.trigger(ConfigChangedEvent, { owner, repo });
+        }, 5000);
     }
 
     private genKey(owner: string, repo: string): string {


### PR DESCRIPTION
* New repo install can not trigger repo install added event if the repo is installed along with the installation, so need to listen on installation created event to handle this.
* Config file created can not be loaded right after event, give 5 seconds delay.